### PR TITLE
Add comprehensive tests and CI for executors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/examples/data_science_examples.py
+++ b/examples/data_science_examples.py
@@ -1,0 +1,43 @@
+"""Example script demonstrating natural language to Python execution."""
+
+from codefull import ExecutionTemplate, ParameterType, NaturalLanguageExecutor
+
+
+def build_executor():
+    nl = NaturalLanguageExecutor()
+    nl.templates = [
+        ExecutionTemplate(
+            "set {var} to {value}",
+            "execute_assignment",
+            parameters={"var": ParameterType.IDENTIFIER, "value": ParameterType.VALUE},
+        ),
+        ExecutionTemplate(
+            "create a list named {var} with {value}",
+            "execute_list_creation",
+            parameters={"var": ParameterType.IDENTIFIER, "value": ParameterType.COLLECTION},
+        ),
+        ExecutionTemplate(
+            "add {value} to {var}",
+            "execute_add_to_var",
+            parameters={"var": ParameterType.IDENTIFIER, "value": ParameterType.VALUE},
+        ),
+        ExecutionTemplate(
+            "print {value}",
+            "execute_print",
+            parameters={"value": ParameterType.IDENTIFIER},
+        ),
+    ]
+    return nl
+
+
+def main():
+    nl = build_executor()
+    print(nl.execute("set count to 10"))
+    print(nl.execute("add 5 to count"))
+    print(nl.execute("print count"))
+    print(nl.execute("create a list named data with 1,2,3"))
+    print(nl.execute("print data"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_code_templates.py
+++ b/tests/test_code_templates.py
@@ -1,0 +1,23 @@
+import importlib.machinery
+import pathlib
+import types
+import string
+
+# Load codefull module
+path = pathlib.Path(__file__).resolve().parents[1] / "codefull"
+loader = importlib.machinery.SourceFileLoader("codefull_module", str(path))
+codefull = types.ModuleType("codefull_module")
+loader.exec_module(codefull)
+
+PythonCodeGenerator = codefull.PythonCodeGenerator
+
+
+def test_all_templates_generate_code():
+    generator = PythonCodeGenerator()
+    formatter = string.Formatter()
+
+    for key, template in generator.code_templates.items():
+        fields = [name for _, name, _, _ in formatter.parse(template) if name]
+        params = {field: "0" for field in fields}
+        code = generator.generate_code(key, **params)
+        assert isinstance(code, str)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,51 @@
+import importlib.machinery
+import pathlib
+import types
+
+# Load codefull module
+path = pathlib.Path(__file__).resolve().parents[1] / "codefull"
+loader = importlib.machinery.SourceFileLoader("codefull_module", str(path))
+codefull = types.ModuleType("codefull_module")
+loader.exec_module(codefull)
+
+ExecutionTemplate = codefull.ExecutionTemplate
+ParameterType = codefull.ParameterType
+NaturalLanguageExecutor = codefull.NaturalLanguageExecutor
+
+
+def build_executor():
+    nl = NaturalLanguageExecutor()
+    nl.templates = [
+        ExecutionTemplate(
+            "set {var} to {value}",
+            "execute_assignment",
+            parameters={"var": ParameterType.IDENTIFIER, "value": ParameterType.VALUE},
+        ),
+        ExecutionTemplate(
+            "add {value} to {var}",
+            "execute_add_to_var",
+            parameters={"var": ParameterType.IDENTIFIER, "value": ParameterType.VALUE},
+        ),
+        ExecutionTemplate(
+            "print {value}",
+            "execute_print",
+            parameters={"value": ParameterType.IDENTIFIER},
+        ),
+    ]
+    return nl
+
+
+def test_natural_language_roundtrip():
+    nl = build_executor()
+    assert "Variables" in nl.execute("set total to 1")
+    assert "total = 3" in nl.execute("add 2 to total")
+    output = nl.execute("print total")
+    assert "Output: 3" in output
+
+
+def test_direct_executor_path():
+    nl = build_executor()
+    codefull._global_executor = nl
+    result = codefull.nl("set value to 7")
+    assert "value = 7" in result
+    codefull.reset_context()


### PR DESCRIPTION
## Summary
- add tests covering code generation templates and natural-language execution path
- provide end-to-end tests and direct executor coverage
- set up GitHub Actions CI workflow to run pytest
- include example script showcasing natural language data-science commands

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3a2e9fe888333b0de5b2e005f1488