### PR TITLE
Add FastAPI interface with session guardrails and smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Natural language DS/ML helper
+
+This prototype exposes a tiny HTTP API for issuing controlled data-science
+commands in natural language. Only a small set of high‑level actions is allowed
+(e.g. load, clean, encode, scale, split, build, fit, transform, evaluate, save).
+
+## How to phrase commands
+
+Copy and adapt the examples below:
+
+```text
+load csv file /path/to/data.csv into df
+clean remove rows with missing values from df
+encode one hot encode column city in df
+scale standard scale columns age and income in df
+split df into train and test sets
+build pipeline with standard scaler and logistic regression
+fit pipeline on train
+evaluate pipeline on test
+save pipeline to model.joblib
+reset session
+```
+
+Send a POST request to `/execute`:
+
+```bash
+curl -X POST localhost:8000/execute -H 'Content-Type: application/json' \
+     -d '{"command": "load csv file data.csv into df"}'
+```

--- a/api.py
+++ b/api.py
@@ -1,0 +1,97 @@
+import logging
+import re
+import time
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from codefull import (
+    NaturalLanguageExecutor,
+    start_session,
+    resume_session,
+    terminate_session,
+)
+
+app = FastAPI()
+logger = logging.getLogger("api")
+logging.basicConfig(level=logging.INFO)
+
+ALLOWED_COMMANDS = {
+    "load",
+    "clean",
+    "encode",
+    "scale",
+    "split",
+    "build",
+    "fit",
+    "transform",
+    "evaluate",
+    "save",
+    "train",
+    "reset",
+}
+
+class CommandRequest(BaseModel):
+    command: str
+    session_id: str | None = None
+
+class CommandResponse(BaseModel):
+    session_id: str
+    success: bool
+    output: str
+    error: str | None = None
+
+
+def _sanitize_error(msg: str) -> str:
+    return re.sub(r"/[^\s]+", "<path>", msg)
+
+
+def _get_session(session_id: str | None):
+    if session_id:
+        session = resume_session(session_id)
+        if session:
+            return session
+    return start_session()
+
+
+@app.post("/execute", response_model=CommandResponse)
+def execute(req: CommandRequest):
+    start = time.time()
+    cmd = req.command.strip()
+    first = cmd.split(" ", 1)[0].lower()
+
+    if cmd.lower() == "reset session":
+        if req.session_id:
+            terminate_session(req.session_id)
+        session = start_session()
+        logger.info("cmd='reset session' duration=%.3fs success=True", time.time() - start)
+        return CommandResponse(session_id=session.id, success=True, output="Session reset.")
+
+    if first not in ALLOWED_COMMANDS:
+        logger.warning("cmd=%s not allowed", cmd)
+        raise HTTPException(status_code=400, detail="Command not permitted.")
+
+    session = _get_session(req.session_id)
+    executor = NaturalLanguageExecutor()
+    executor.context = session.context
+
+    try:
+        result = executor.execute(cmd)
+        success = not result.startswith("✗")
+        duration = time.time() - start
+        logger.info(
+            "cmd=%s duration=%.3fs success=%s",
+            cmd,
+            duration,
+            success,
+        )
+        return CommandResponse(
+            session_id=session.id,
+            success=success,
+            output=result if success else "",
+            error=None if success else result,
+        )
+    except Exception as exc:
+        duration = time.time() - start
+        msg = _sanitize_error(str(exc))
+        logger.error("cmd=%s duration=%.3fs error=%s", cmd, duration, msg)
+        raise HTTPException(status_code=500, detail=f"Execution failed: {msg}")

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -1,0 +1,29 @@
+import pathlib
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pandas = pytest.importorskip("pandas")
+from fastapi.testclient import TestClient
+
+from api import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_execute_and_reset(client, tmp_path):
+    csv = tmp_path / "data.csv"
+    csv.write_text("a,b\n1,2\n")
+    resp = client.post("/execute", json={"command": f"load csv file {csv} into df"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"]
+    sid = data["session_id"]
+
+    resp = client.post(
+        "/execute", json={"command": "reset session", "session_id": sid}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["output"] == "Session reset."

--- a/tests/test_dataset_manager_smoke.py
+++ b/tests/test_dataset_manager_smoke.py
@@ -1,0 +1,60 @@
+import pytest
+
+pandas = pytest.importorskip("pandas")
+sklearn = pytest.importorskip("sklearn")
+
+from dataset_management import DatasetManager, Schema, PipelineConfig
+
+
+def _make_df():
+    import pandas as pd
+    df = pd.DataFrame({
+        "age": [20, 30, 40, 50, 60] * 20,
+        "income": [10, 20, 30, 40, 50] * 20,
+        "city": ["A", "B", "A", "B", "C"] * 20,
+        "target": [0, 1, 0, 1, 0] * 20,
+    })
+    return df
+
+CONFIGS = [
+    {"use_robust_scaler": False, "use_quantile_transform": False},
+    {"use_robust_scaler": True, "use_quantile_transform": False},
+    {"use_robust_scaler": False, "use_quantile_transform": True},
+    {"use_robust_scaler": True, "use_quantile_transform": True},
+    {"power_transform": "yeo-johnson"},
+    {"select_k_best": 1},
+    {"variance_threshold": 0.0},
+    {"use_robust_scaler": True, "select_k_best": 1},
+    {"use_quantile_transform": True, "power_transform": "yeo-johnson"},
+    {"use_robust_scaler": True, "variance_threshold": 0.0},
+]
+
+
+@pytest.mark.parametrize("cfg", CONFIGS)
+def test_end_to_end(cfg, tmp_path):
+    import pandas as pd
+    from sklearn.linear_model import LogisticRegression
+
+    df = _make_df()
+    schema = Schema(
+        numeric=["age", "income"],
+        categorical=["city"],
+        target="target",
+        dtypes={"age": "int64", "income": "int64", "city": "object", "target": "int64"},
+        categories={"city": ["A", "B", "C"]},
+    )
+    dm = DatasetManager(schema, pipeline_cfg=PipelineConfig(**cfg))
+    df_clean, report = dm.validate_and_clean(df, coerce_dtypes=True)
+    assert not report["missing_columns"]
+    train, val, test, *_ = dm.train_val_test_split(df_clean)
+    dm.fit(train)
+    Xt = dm.transform(val)
+    model = LogisticRegression()
+    model.fit(Xt, val["target"])
+    preds = model.predict(dm.transform(test))
+    assert preds.shape[0] == test.shape[0]
+    path = tmp_path / "pipe.joblib"
+    dm.save_pipeline(path)
+    dm.load_pipeline(path)
+    Xt2 = dm.transform(test)
+    assert Xt2.shape[0] == test.shape[0]


### PR DESCRIPTION
## Summary
- expose `/execute` FastAPI endpoint with per-session context, command allow list, and logging
- document supported natural language commands in a new README
- add smoke tests for HTTP API and dataset manager pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3f63dd9d88333843bea5390c5492d