### PR TITLE
Add /parse endpoint to mirror /execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This prototype exposes a tiny HTTP API for issuing controlled data-science
 commands in natural language. Only a small set of high‑level actions is allowed
 (e.g. load, clean, encode, scale, split, build, fit, transform, evaluate, save).
+Commands are sent to the `/parse` endpoint, which behaves the same as the
+legacy `/execute` endpoint kept for backward compatibility.
 
 ## How to phrase commands
 
@@ -21,9 +23,9 @@ save pipeline to model.joblib
 reset session
 ```
 
-Send a POST request to `/execute`:
+Send a POST request to `/parse` (or `/execute` for backward compatibility):
 
 ```bash
-curl -X POST localhost:8000/execute -H 'Content-Type: application/json' \
+curl -X POST localhost:8000/parse -H 'Content-Type: application/json' \
      -d '{"command": "load csv file data.csv into df"}'
 ```

--- a/api.py
+++ b/api.py
@@ -95,3 +95,8 @@ def execute(req: CommandRequest):
         msg = _sanitize_error(str(exc))
         logger.error("cmd=%s duration=%.3fs error=%s", cmd, duration, msg)
         raise HTTPException(status_code=500, detail=f"Execution failed: {msg}")
+
+
+@app.post("/parse", response_model=CommandResponse)
+def parse(req: CommandRequest):
+    return execute(req)


### PR DESCRIPTION
## Summary
- Expose new `/parse` POST endpoint that delegates to existing `execute` logic
- Document `/parse` in the README while keeping `/execute` for compatibility

## Testing
- `pytest` *(fails: terminated after long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fd684c9483338efce0a13a13bc48