### PR TITLE
Handle missing imblearn samplers gracefully

### DIFF
--- a/api.py
+++ b/api.py
@@ -90,6 +90,16 @@ def execute(req: CommandRequest):
             output=result if success else "",
             error=None if success else result,
         )
+    except ValueError as exc:
+        duration = time.time() - start
+        msg = _sanitize_error(str(exc))
+        logger.error("cmd=%s duration=%.3fs error=%s", cmd, duration, msg)
+        return CommandResponse(
+            session_id=session.id,
+            success=False,
+            output="",
+            error=msg,
+        )
     except Exception as exc:
         duration = time.time() - start
         msg = _sanitize_error(str(exc))

--- a/dataset_management.py
+++ b/dataset_management.py
@@ -485,9 +485,13 @@ class DatasetManager:
         y: np.ndarray,
         method: str = "smote",
     ) -> Tuple[np.ndarray, np.ndarray]:
-        if method == "smote" and SMOTE:
+        if method == "smote":
+            if SMOTE is None:
+                raise ValueError("Install imblearn to use SMOTE/ADASYN")
             sampler = SMOTE(random_state=self.random_state)
-        elif method == "adasyn" and ADASYN:
+        elif method == "adasyn":
+            if ADASYN is None:
+                raise ValueError("Install imblearn to use SMOTE/ADASYN")
             sampler = ADASYN(random_state=self.random_state)
         else:
             raise ValueError("Requested resampling method not available")

--- a/tests/test_resampling_error.py
+++ b/tests/test_resampling_error.py
@@ -1,0 +1,30 @@
+import pytest
+
+
+def test_apply_resampling_requires_imblearn(monkeypatch):
+    dm_mod = pytest.importorskip("dataset_management")
+    monkeypatch.setattr(dm_mod, "SMOTE", None)
+    schema = dm_mod.Schema(numeric=["a"], target="b")
+    dm = dm_mod.DatasetManager(schema)
+    X = [[1], [2]]
+    y = [0, 1]
+    with pytest.raises(ValueError, match="Install imblearn to use SMOTE/ADASYN"):
+        dm.apply_resampling(X, y, method="smote")
+
+
+def test_api_returns_error_on_value_error(monkeypatch):
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+    import api
+
+    client = TestClient(api.app)
+
+    def fake_execute(self, cmd):
+        raise ValueError("Install imblearn to use SMOTE/ADASYN")
+
+    monkeypatch.setattr(api.NaturalLanguageExecutor, "execute", fake_execute)
+    resp = client.post("/execute", json={"command": "load data"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert not data["success"]
+    assert data["error"] == "Install imblearn to use SMOTE/ADASYN"


### PR DESCRIPTION
## Summary
- Raise clear error when SMOTE or ADASYN samplers are unavailable
- Surface resampling errors through `api.execute`
- Test for resampling failures and API error propagation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3ffdf1348833388ccd2b0409b4176