### PR TITLE
Add pandas and sklearn templates and tests

### DIFF
--- a/templates/__init__.py
+++ b/templates/__init__.py
@@ -9,11 +9,19 @@ TASK_INVENTORY = {
     "data_loading": {
         "read_csv": pandas.TEMPLATES.get("read_csv"),
     },
+    "dataframe_operations": {
+        "dropna": pandas.TEMPLATES.get("dropna"),
+        "merge": pandas.TEMPLATES.get("merge"),
+        "groupby": pandas.TEMPLATES.get("groupby"),
+    },
     "preprocessing": {
         "standard_scaler": sklearn.TEMPLATES.get("standard_scaler"),
+        "train_test_split": sklearn.TEMPLATES.get("train_test_split"),
+        "pca": sklearn.TEMPLATES.get("pca"),
     },
     "model_training": {
         "logistic_regression": sklearn.TEMPLATES.get("logistic_regression"),
+        "random_forest": sklearn.TEMPLATES.get("random_forest"),
     },
 }
 

--- a/templates/pandas.py
+++ b/templates/pandas.py
@@ -44,6 +44,21 @@ TEMPLATES: Dict[str, Template] = {
         parameters={"path": "str", "sep": "str"},
         code="pd.read_csv({path!r}, sep={sep!r})",
     ),
+    "dropna": Template(
+        pattern="drop missing values",
+        parameters={},
+        code="df.dropna()",
+    ),
+    "merge": Template(
+        pattern="merge df1 with df2 on {on}",
+        parameters={"on": "str"},
+        code="df1.merge(df2, on={on!r})",
+    ),
+    "groupby": Template(
+        pattern="group by {column} with {agg}",
+        parameters={"column": "str", "agg": "str"},
+        code="df.groupby({column!r}).{agg}()",
+    ),
 }
 
 __all__ = ["TEMPLATES", "Template", "HAS_PANDAS"]

--- a/templates/sklearn.py
+++ b/templates/sklearn.py
@@ -18,6 +18,9 @@ try:  # pragma: no cover - optional dependency
     import sklearn  # type: ignore
     from sklearn.preprocessing import StandardScaler  # noqa: F401
     from sklearn.linear_model import LogisticRegression  # noqa: F401
+    from sklearn.model_selection import train_test_split  # noqa: F401
+    from sklearn.decomposition import PCA  # noqa: F401
+    from sklearn.ensemble import RandomForestClassifier  # noqa: F401
     _version = _parse_version(sklearn.__version__)
     HAS_SKLEARN = _version >= (1, 0, 0)
 except Exception:  # pragma: no cover - sklearn missing
@@ -43,10 +46,25 @@ TEMPLATES: Dict[str, Template] = {
         parameters={"columns": "list[str]"},
         code="scaler = StandardScaler();\nscaled = scaler.fit_transform(df[{columns!r}])",
     ),
+    "train_test_split": Template(
+        pattern="split data into train and test sets",
+        parameters={"test_size": "float", "random_state": "int"},
+        code="X_train, X_test, y_train, y_test = train_test_split(X, y, test_size={test_size}, random_state={random_state})",
+    ),
+    "pca": Template(
+        pattern="apply PCA with {n_components} components",
+        parameters={"n_components": "int"},
+        code="pca = PCA(n_components={n_components});\ntransformed = pca.fit_transform(X)",
+    ),
     "logistic_regression": Template(
         pattern="fit logistic regression",
         parameters={},
         code="model = LogisticRegression();\nmodel.fit(X, y)",
+    ),
+    "random_forest": Template(
+        pattern="fit random forest classifier",
+        parameters={},
+        code="model = RandomForestClassifier();\nmodel.fit(X, y)",
     ),
 }
 

--- a/tests/test_templates_workflow.py
+++ b/tests/test_templates_workflow.py
@@ -12,8 +12,14 @@ pytestmark = pytest.mark.skipif(
 
 def test_inventory_contains_core_tasks():
     assert "read_csv" in TASK_INVENTORY["data_loading"]
+    assert "dropna" in TASK_INVENTORY["dataframe_operations"]
+    assert "merge" in TASK_INVENTORY["dataframe_operations"]
+    assert "groupby" in TASK_INVENTORY["dataframe_operations"]
     assert "standard_scaler" in TASK_INVENTORY["preprocessing"]
+    assert "train_test_split" in TASK_INVENTORY["preprocessing"]
+    assert "pca" in TASK_INVENTORY["preprocessing"]
     assert "logistic_regression" in TASK_INVENTORY["model_training"]
+    assert "random_forest" in TASK_INVENTORY["model_training"]
 
 
 def test_end_to_end_workflow(tmp_path):
@@ -37,4 +43,51 @@ def test_end_to_end_workflow(tmp_path):
     ns = {"X": scaled, "y": df["target"], "LogisticRegression": LogisticRegression}
     exec(train_code, ns)
     model = ns["model"]
+    assert hasattr(model, "predict")
+
+
+def test_pandas_templates():
+    import pandas as pd
+
+    df = pd.DataFrame({"a": [1, None, 3]})
+    drop_code = pandas_templates.TEMPLATES["dropna"].generate()
+    cleaned = eval(drop_code, {"df": df})
+    assert cleaned.isna().sum().sum() == 0
+
+    df1 = pd.DataFrame({"id": [1, 2], "val": [10, 20]})
+    df2 = pd.DataFrame({"id": [1, 3], "val2": [7, 8]})
+    merge_code = pandas_templates.TEMPLATES["merge"].generate(on="id")
+    merged = eval(merge_code, {"df1": df1, "df2": df2})
+    assert merged.shape == (1, 3)
+
+    df_group = pd.DataFrame({"key": ["x", "x", "y"], "val": [1, 2, 3]})
+    group_code = pandas_templates.TEMPLATES["groupby"].generate(column="key", agg="sum")
+    grouped = eval(group_code, {"df": df_group})
+    assert grouped.loc["x", "val"] == 3
+
+
+def test_sklearn_templates():
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    from sklearn.decomposition import PCA
+    from sklearn.ensemble import RandomForestClassifier
+
+    X = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+    y = np.array([0, 1, 0, 1])
+
+    split_code = sklearn_templates.TEMPLATES["train_test_split"].generate(test_size=0.5, random_state=0)
+    ns = {"X": X, "y": y, "train_test_split": train_test_split}
+    exec(split_code, ns)
+    assert ns["X_train"].shape[0] == 2
+
+    pca_code = sklearn_templates.TEMPLATES["pca"].generate(n_components=1)
+    ns_pca = {"X": ns["X_train"], "PCA": PCA}
+    exec(pca_code, ns_pca)
+    transformed = ns_pca["transformed"]
+    assert transformed.shape == (2, 1)
+
+    rf_code = sklearn_templates.TEMPLATES["random_forest"].generate()
+    ns_rf = {"X": ns["X_train"], "y": ns["y_train"], "RandomForestClassifier": RandomForestClassifier}
+    exec(rf_code, ns_rf)
+    model = ns_rf["model"]
     assert hasattr(model, "predict")


### PR DESCRIPTION
## Summary
- expand pandas templates with dropna, merge, and groupby operations
- extend sklearn templates with train_test_split, PCA, and random_forest utilities
- register new templates in TASK_INVENTORY and add workflow tests

## Testing
- `pip install pandas scikit-learn` *(fails: Could not find a version that satisfies the requirement pandas; No matching distribution found)*
- `pytest tests/test_templates_workflow.py -q` *(skipped: pandas and scikit-learn are required)*

------
https://chatgpt.com/codex/tasks/task_e_68a41111c0848333b5942dd1611910a9