### PR TITLE
Allow inferring sample size for time series splits

### DIFF
--- a/tests/test_time_series_splits.py
+++ b/tests/test_time_series_splits.py
@@ -1,0 +1,23 @@
+import pytest
+
+pandas = pytest.importorskip("pandas")
+
+from dataset_management import DatasetManager, Schema
+
+
+def test_time_series_splits_infers_length_from_df():
+    df = pandas.DataFrame({"a": range(10)})
+    dm = DatasetManager(Schema())
+    splits = list(dm.time_series_splits(n_splits=3, df_or_length=df))
+    assert len(splits) == 3
+    for train_idx, test_idx in splits:
+        assert len(test_idx) == 2
+        assert max(test_idx) < len(df)
+
+
+def test_label_time_series_folds_uses_inference():
+    df = pandas.DataFrame({"a": range(10)})
+    dm = DatasetManager(Schema())
+    labelled = dm.label_time_series_folds(df, n_splits=3)
+    assert "fold" in labelled.columns
+    assert set(labelled["fold"].unique()) == {-1, 0, 1, 2}


### PR DESCRIPTION
## Summary
- allow `time_series_splits` to infer `n_samples` from a dataframe or array via a new `df_or_length` parameter
- update `label_time_series_folds` and `run_template` to use the new signature
- document the revised API and add tests for automatic inference

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4ab5d079483339a9fef895990783d