### PR TITLE
Add feature engineering and evaluation templates

### DIFF
--- a/templates/__init__.py
+++ b/templates/__init__.py
@@ -23,6 +23,13 @@ TASK_INVENTORY = {
         "logistic_regression": sklearn.TEMPLATES.get("logistic_regression"),
         "random_forest": sklearn.TEMPLATES.get("random_forest"),
     },
+    "feature_engineering": {
+        "one_hot_encode": pandas.TEMPLATES.get("one_hot_encode"),
+        "polynomial_features": sklearn.TEMPLATES.get("polynomial_features"),
+    },
+    "model_evaluation": {
+        "accuracy_score": sklearn.TEMPLATES.get("accuracy_score"),
+    },
 }
 
 __all__ = ["TASK_INVENTORY", "pandas", "sklearn"]

--- a/templates/pandas.py
+++ b/templates/pandas.py
@@ -59,6 +59,11 @@ TEMPLATES: Dict[str, Template] = {
         parameters={"column": "str", "agg": "str"},
         code="df.groupby({column!r}).{agg}()",
     ),
+    "one_hot_encode": Template(
+        pattern="one-hot encode columns {columns}",
+        parameters={"columns": "list[str]"},
+        code="pd.get_dummies(df, columns={columns!r})",
+    ),
 }
 
 __all__ = ["TEMPLATES", "Template", "HAS_PANDAS"]

--- a/templates/sklearn.py
+++ b/templates/sklearn.py
@@ -17,9 +17,11 @@ def _parse_version(v: str) -> tuple[int, ...]:
 try:  # pragma: no cover - optional dependency
     import sklearn  # type: ignore
     from sklearn.preprocessing import StandardScaler  # noqa: F401
+    from sklearn.preprocessing import PolynomialFeatures  # noqa: F401
     from sklearn.linear_model import LogisticRegression  # noqa: F401
     from sklearn.model_selection import train_test_split  # noqa: F401
     from sklearn.decomposition import PCA  # noqa: F401
+    from sklearn.metrics import accuracy_score  # noqa: F401
     from sklearn.ensemble import RandomForestClassifier  # noqa: F401
     _version = _parse_version(sklearn.__version__)
     HAS_SKLEARN = _version >= (1, 0, 0)
@@ -56,6 +58,11 @@ TEMPLATES: Dict[str, Template] = {
         parameters={"n_components": "int"},
         code="pca = PCA(n_components={n_components});\ntransformed = pca.fit_transform(X)",
     ),
+    "polynomial_features": Template(
+        pattern="generate polynomial features of degree {degree}",
+        parameters={"degree": "int"},
+        code="poly = PolynomialFeatures(degree={degree});\nfeatures = poly.fit_transform(X)",
+    ),
     "logistic_regression": Template(
         pattern="fit logistic regression",
         parameters={},
@@ -65,6 +72,11 @@ TEMPLATES: Dict[str, Template] = {
         pattern="fit random forest classifier",
         parameters={},
         code="model = RandomForestClassifier();\nmodel.fit(X, y)",
+    ),
+    "accuracy_score": Template(
+        pattern="compute accuracy score",
+        parameters={},
+        code="score = accuracy_score(y_true, y_pred)",
     ),
 }
 


### PR DESCRIPTION
## Summary
- add pandas template for one-hot encoding
- add sklearn templates for polynomial features and accuracy score
- reference new templates in TASK_INVENTORY

## Testing
- `pytest` *(failed: tests/test_python_executor.py::test_benign_code)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ae2831088333ac4deeb82c1c53bb