### PR TITLE
Refactor monolithic execution into modular components

### DIFF
--- a/api.py
+++ b/api.py
@@ -4,7 +4,7 @@ import time
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
-from codefull import (
+from execution import (
     NaturalLanguageExecutor,
     start_session,
     resume_session,

--- a/dataset_commands.py
+++ b/dataset_commands.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Optional
+
+
+class DatasetCommandMixin:
+    """Mixin providing dataset manager commands."""
+
+    dataset_manager = None
+
+    def _dataset_load(self, df_name: str, target: str) -> str:
+        from dataset_management import DatasetManager, Schema  # type: ignore
+        import pandas as pd  # noqa: F401
+
+        df = self.context.get_variable(df_name)
+        if df is None:
+            return "\u2717 dataframe not found"
+        numeric = [c for c in df.select_dtypes(include="number").columns if c != target]
+        categorical = [
+            c for c in df.select_dtypes(exclude="number").columns if c != target
+        ]
+        dtypes = {c: str(df[c].dtype) for c in df.columns}
+        schema = Schema(numeric=numeric, categorical=categorical, target=target, dtypes=dtypes)
+        self.dataset_manager = DatasetManager(schema)
+        return "dataset manager loaded"
+
+    def _dataset_validate(self, df_name: str) -> str:
+        if self.dataset_manager is None:
+            return "\u2717 dataset manager not loaded"
+        df = self.context.get_variable(df_name)
+        if df is None:
+            return "\u2717 dataframe not found"
+        report = self.dataset_manager.validate(df)
+        return str(report)
+
+    def _dataset_split(self, df_name: str) -> str:
+        if self.dataset_manager is None:
+            return "\u2717 dataset manager not loaded"
+        df = self.context.get_variable(df_name)
+        if df is None:
+            return "\u2717 dataframe not found"
+        train, val, test, *_ = self.dataset_manager.train_val_test_split(df)
+        self.context.add_variable("train_df", train)
+        self.context.add_variable("val_df", val)
+        self.context.add_variable("test_df", test)
+        return "dataset split into train_df, val_df, test_df"
+
+    def handle_dataset_command(self, user_input: str) -> Optional[str]:
+        lower_input = user_input.lower()
+        if lower_input.startswith("dataset_load "):
+            parts = user_input.split()
+            if len(parts) >= 4:
+                return self._dataset_load(parts[1], parts[3])
+            return "\u2717 invalid dataset_load command"
+        if lower_input.startswith("dataset_validate "):
+            parts = user_input.split()
+            if len(parts) >= 2:
+                return self._dataset_validate(parts[1])
+            return "\u2717 invalid dataset_validate command"
+        if lower_input.startswith("dataset_split "):
+            parts = user_input.split()
+            if len(parts) >= 2:
+                return self._dataset_split(parts[1])
+            return "\u2717 invalid dataset_split command"
+        return None

--- a/execution.py
+++ b/execution.py
@@ -21,32 +21,9 @@ except Exception:  # pragma: no cover - fallback when dependency missing
     MLCodeGenerator = None
 
 logger = logging.getLogger(__name__)
+from parsing import (ParameterExtractionError, ParameterType, ExecutionTemplate, ParameterExtractor)
+from dataset_commands import DatasetCommandMixin
 
-
-class ParameterExtractionError(Exception):
-    """Raised when a parameter cannot be parsed"""
-    pass
-
-class ParameterType(Enum):
-    IDENTIFIER = "identifier"
-    VALUE = "value"
-    CONDITION = "condition"
-    EXPRESSION = "expression"
-    TYPE = "type"
-    STATEMENT = "statement"
-    COLLECTION = "collection"
-
-@dataclass
-class ExecutionTemplate:
-    pattern: str
-    execution_func: str  # Function to call for execution
-    code_template: str = ""  # NEW: Python code template for real execution
-    parameters: Dict[str, ParameterType] = None
-    priority: int = 1
-    
-    def __post_init__(self):
-        if self.parameters is None:
-            self.parameters = {}
 
 class PythonCodeGenerator:  # COMPLETED: Real Python code generation for ALL templates
     """Generates actual Python code from natural language - COMPLETE IMPLEMENTATION"""
@@ -589,133 +566,7 @@ def resume_session(session_id: str) -> Optional[Session]:
 def terminate_session(session_id: str):
     _session_manager.terminate_session(session_id)
 
-class ParameterExtractor:
-    def __init__(self, context: ExecutionContext):
-        self.context = context
-        self.number_words = {
-            "zero": 0, "one": 1, "two": 2, "three": 3, "four": 4,
-            "five": 5, "six": 6, "seven": 7, "eight": 8, "nine": 9,
-            "ten": 10
-        }
-        self.ordinal_words = {
-            "first": 1, "second": 2, "third": 3, "fourth": 4, "fifth": 5,
-            "sixth": 6, "seventh": 7, "eighth": 8, "ninth": 9, "tenth": 10
-        }
-        self.boolean_words = {
-            "true": True, "false": False, "yes": True, "no": False
-        }
-        self.identifier_synonyms = {
-            "ids": "id",
-            "identifiers": "id",
-            "identifier": "id"
-        }
-
-    def _tokenize(self, text: str) -> List[str]:
-        try:
-            return shlex.split(text)
-        except Exception:
-            return text.split()
-        
-    def extract_identifier(self, text: str) -> str:
-        """Convert natural language to Python identifier"""
-        resolved = self.context.resolve_reference(text)
-        if resolved and resolved != text:
-            return resolved
-
-        tokens = [t.lower() for t in self._tokenize(text)]
-        if not tokens:
-            raise ParameterExtractionError(f"Cannot resolve identifier from '{text}'")
-
-        normalized: List[str] = []
-        for tok in tokens:
-            tok = ''.join(ch for ch in tok if ch.isalnum() or ch == '_')
-            tok = self.identifier_synonyms.get(tok, tok)
-            normalized.append(tok)
-
-        identifier = '_'.join(normalized)
-        if not identifier:
-            raise ParameterExtractionError(f"Cannot resolve identifier from '{text}'")
-        return identifier
-    
-    def extract_value(self, text: str) -> Any:
-        """Extract and convert values to appropriate Python types"""
-        text = text.strip()
-        tokens = self._tokenize(text)
-        if not tokens:
-            raise ParameterExtractionError(f"Cannot resolve value from '{text}'")
-
-        if len(tokens) == 1:
-            token = tokens[0]
-            lower = token.lower()
-
-            if lower.isdigit():
-                return int(lower)
-            if lower in self.number_words:
-                return self.number_words[lower]
-            if lower in self.ordinal_words:
-                return self.ordinal_words[lower]
-            try:
-                return float(lower)
-            except ValueError:
-                pass
-            if lower in self.boolean_words:
-                return self.boolean_words[lower]
-            if lower in self.context.variables:
-                return self.context.variables[lower]
-            return token
-
-        return ' '.join(tokens)
-    
-    def extract_condition_parts(self, text: str) -> Tuple[Any, str, Any]:
-        """Extract condition parts for evaluation"""
-        tokens = [t.lower() for t in self._tokenize(text)]
-        operator_map = {
-            ('is', 'equal', 'to'): '==',
-            ('equals',): '==',
-            ('is', 'greater', 'than'): '>',
-            ('is', 'less', 'than'): '<',
-            ('is', 'greater', 'than', 'or', 'equal', 'to'): '>=',
-            ('is', 'less', 'than', 'or', 'equal', 'to'): '<=',
-            ('is', 'not', 'equal', 'to'): '!=',
-            ('contains',): 'in',
-            ('is', 'in'): 'in',
-            ('is', 'not', 'in'): 'not in'
-        }
-
-        for phrase, op in operator_map.items():
-            length = len(phrase)
-            for i in range(len(tokens) - length + 1):
-                if tokens[i:i + length] == list(phrase):
-                    left_tokens = tokens[:i]
-                    right_tokens = tokens[i + length:]
-                    left = self.extract_value(' '.join(left_tokens))
-                    right = self.extract_value(' '.join(right_tokens))
-                    return left, op, right
-
-        raise ParameterExtractionError(f"Cannot parse condition '{text}'")
-    
-    def extract_collection(self, text: str) -> List[Any]:
-        """Extract collection from natural language"""
-        text = text.strip()
-        
-        if text.startswith('[') and text.endswith(']'):
-            # Already a list literal, evaluate it safely
-            try:
-                return eval(text)
-            except:
-                pass
-        
-        # Handle comma-separated values
-        if ',' in text:
-            items = []
-            for item in text.split(','):
-                items.append(self.extract_value(item.strip()))
-            return items
-        
-        # Single item
-        return [self.extract_value(text)]
-
-class NaturalLanguageExecutor:
+class NaturalLanguageExecutor(DatasetCommandMixin):
     def __init__(self):
         self.context = ExecutionContext()
         self.extractor = ParameterExtractor(self.context)
@@ -5550,22 +5401,9 @@ print(f"Memory stats: {object_count} objects tracked, {len(stats)} generations")
         user_input = user_input.strip()
         lower_input = user_input.lower()
 
-        # Dataset manager direct commands
-        if lower_input.startswith("dataset_load "):
-            parts = user_input.split()
-            if len(parts) >= 4:
-                return self._dataset_load(parts[1], parts[3])
-            return "\u2717 invalid dataset_load command"
-        if lower_input.startswith("dataset_validate "):
-            parts = user_input.split()
-            if len(parts) >= 2:
-                return self._dataset_validate(parts[1])
-            return "\u2717 invalid dataset_validate command"
-        if lower_input.startswith("dataset_split "):
-            parts = user_input.split()
-            if len(parts) >= 2:
-                return self._dataset_split(parts[1])
-            return "\u2717 invalid dataset_split command"
+        cmd_result = self.handle_dataset_command(user_input)
+        if cmd_result is not None:
+            return cmd_result
 
         # Handle context-dependent references
         if "the list" in lower_input and self.context.last_collection:

--- a/parsing.py
+++ b/parsing.py
@@ -1,0 +1,156 @@
+import shlex
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Tuple
+
+
+class ParameterExtractionError(Exception):
+    """Raised when a parameter cannot be parsed"""
+    pass
+
+
+class ParameterType(Enum):
+    IDENTIFIER = "identifier"
+    VALUE = "value"
+    CONDITION = "condition"
+    EXPRESSION = "expression"
+    TYPE = "type"
+    STATEMENT = "statement"
+    COLLECTION = "collection"
+
+
+@dataclass
+class ExecutionTemplate:
+    pattern: str
+    execution_func: str  # Function to call for execution
+    code_template: str = ""  # Python code template for real execution
+    parameters: Dict[str, ParameterType] | None = None
+    priority: int = 1
+
+    def __post_init__(self) -> None:
+        if self.parameters is None:
+            self.parameters = {}
+
+
+class ParameterExtractor:
+    def __init__(self, context: "ExecutionContext") -> None:
+        self.context = context
+        self.number_words = {
+            "zero": 0, "one": 1, "two": 2, "three": 3, "four": 4,
+            "five": 5, "six": 6, "seven": 7, "eight": 8, "nine": 9,
+            "ten": 10,
+        }
+        self.ordinal_words = {
+            "first": 1, "second": 2, "third": 3, "fourth": 4, "fifth": 5,
+            "sixth": 6, "seventh": 7, "eighth": 8, "ninth": 9, "tenth": 10,
+        }
+        self.boolean_words = {
+            "true": True, "false": False, "yes": True, "no": False,
+        }
+        self.identifier_synonyms = {
+            "ids": "id",
+            "identifiers": "id",
+            "identifier": "id",
+        }
+
+    def _tokenize(self, text: str) -> List[str]:
+        try:
+            return shlex.split(text)
+        except Exception:
+            return text.split()
+
+    def extract_identifier(self, text: str) -> str:
+        """Convert natural language to Python identifier"""
+        resolved = self.context.resolve_reference(text)
+        if resolved and resolved != text:
+            return resolved
+
+        tokens = [t.lower() for t in self._tokenize(text)]
+        if not tokens:
+            raise ParameterExtractionError(f"Cannot resolve identifier from '{text}'")
+
+        normalized: List[str] = []
+        for tok in tokens:
+            tok = ''.join(ch for ch in tok if ch.isalnum() or ch == '_')
+            tok = self.identifier_synonyms.get(tok, tok)
+            normalized.append(tok)
+
+        identifier = '_'.join(normalized)
+        if not identifier:
+            raise ParameterExtractionError(f"Cannot resolve identifier from '{text}'")
+        return identifier
+
+    def extract_value(self, text: str) -> Any:
+        """Extract and convert values to appropriate Python types"""
+        text = text.strip()
+        tokens = self._tokenize(text)
+        if not tokens:
+            raise ParameterExtractionError(f"Cannot resolve value from '{text}'")
+
+        if len(tokens) == 1:
+            token = tokens[0]
+            lower = token.lower()
+
+            if lower.isdigit():
+                return int(lower)
+            if lower in self.number_words:
+                return self.number_words[lower]
+            if lower in self.ordinal_words:
+                return self.ordinal_words[lower]
+            try:
+                return float(lower)
+            except ValueError:
+                pass
+            if lower in self.boolean_words:
+                return self.boolean_words[lower]
+            if lower in self.context.variables:
+                return self.context.variables[lower]
+            return token
+
+        return ' '.join(tokens)
+
+    def extract_condition_parts(self, text: str) -> Tuple[Any, str, Any]:
+        """Extract condition parts for evaluation"""
+        tokens = [t.lower() for t in self._tokenize(text)]
+        operator_map = {
+            ("is", "equal", "to"): "==",
+            ("equals",): "==",
+            ("is", "greater", "than"): ">",
+            ("is", "less", "than"): "<",
+            ("is", "greater", "than", "or", "equal", "to"): ">=",
+            ("is", "less", "than", "or", "equal", "to"): "<=",
+            ("is", "not", "equal", "to"): "!=",
+            ("contains",): "in",
+            ("is", "in"): "in",
+            ("is", "not", "in"): "not in",
+        }
+
+        for phrase, op in operator_map.items():
+            length = len(phrase)
+            for i in range(len(tokens) - length + 1):
+                if tokens[i:i + length] == list(phrase):
+                    left_tokens = tokens[:i]
+                    right_tokens = tokens[i + length:]
+                    left = self.extract_value(' '.join(left_tokens))
+                    right = self.extract_value(' '.join(right_tokens))
+                    return left, op, right
+
+        raise ParameterExtractionError(f"Cannot parse condition '{text}'")
+
+    def extract_collection(self, text: str) -> List[Any]:
+        """Extract collection from natural language"""
+        text = text.strip()
+
+        if text.startswith('[') and text.endswith(']'):
+            try:
+                return eval(text)
+            except Exception:
+                pass
+
+        if ',' in text:
+            items = []
+            for item in text.split(','):
+                items.append(self.extract_value(item.strip()))
+            return items
+
+        return [self.extract_value(text)]

--- a/tests/test_condition_parser.py
+++ b/tests/test_condition_parser.py
@@ -1,6 +1,6 @@
 import pytest
 
-from codefull import NaturalLanguageExecutor
+from execution import NaturalLanguageExecutor
 
 
 def test_convert_condition_nested():

--- a/tests/test_parameter_extractor.py
+++ b/tests/test_parameter_extractor.py
@@ -1,10 +1,7 @@
 import pytest
 
-from codefull import (
-    ExecutionContext,
-    ParameterExtractionError,
-    ParameterExtractor,
-)
+from execution import ExecutionContext
+from parsing import ParameterExtractionError, ParameterExtractor
 
 
 def make_extractor():

--- a/tests/test_python_executor.py
+++ b/tests/test_python_executor.py
@@ -1,6 +1,6 @@
 import pytest
 
-from codefull import PythonExecutor
+from execution import PythonExecutor
 
 
 def test_benign_code():

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,4 +1,4 @@
-from codefull import resume_session, start_session, terminate_session
+from execution import resume_session, start_session, terminate_session
 
 
 def test_variable_reuse_across_turns():

--- a/tests/test_unknown_commands.py
+++ b/tests/test_unknown_commands.py
@@ -1,4 +1,5 @@
-from codefull import ExecutionTemplate, NaturalLanguageExecutor
+from parsing import ExecutionTemplate
+from execution import NaturalLanguageExecutor
 
 
 def test_unknown_command_message():


### PR DESCRIPTION
## Summary
- Split parsing utilities into `parsing` module and dataset commands into `dataset_commands`
- Refactor execution logic to rely on new modules and expose dataset handlers
- Update API and tests to import from the new modules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4b195de908333ad334127278bc0db