### PR TITLE
Add security tests and document PythonExecutor restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,19 @@ Send a POST request to `/parse` (or `/execute` for backward compatibility):
 curl -X POST localhost:8000/parse -H 'Content-Type: application/json' \
      -d '{"command": "load csv file data.csv into df"}'
 ```
+
+## Security model
+
+The `PythonExecutor` executes generated Python code in a restricted
+environment designed to prevent misuse:
+
+* The abstract syntax tree is validated to block `import` and `from` statements
+  and to disallow calls to `eval`, `exec`, `__import__`, and `open`.
+* Only a small whitelist of safe built-ins (e.g. `print`, `len`, `range`) is
+  exposed to executed code; all other built-ins are unavailable.
+* Code runs in a separate subprocess with CPU time limited to one second and
+  address space capped at roughly 50 MB via `resource` limits.
+* The subprocess is terminated if execution exceeds a one‑second timeout.
+
+These safeguards make code execution best-effort safe while still supporting
+basic educational and data‑science snippets.

--- a/tests/test_python_executor.py
+++ b/tests/test_python_executor.py
@@ -26,6 +26,27 @@ def test_disallowed_eval():
     assert "Disallowed" in result["error"]
 
 
+def test_disallowed_open():
+    executor = PythonExecutor()
+    result = executor.execute_code("open('foo.txt', 'w')")
+    assert result["success"] is False
+    assert "Disallowed" in result["error"]
+
+
+def test_disallowed_exec():
+    executor = PythonExecutor()
+    result = executor.execute_code("exec('print(1)')")
+    assert result["success"] is False
+    assert "Disallowed" in result["error"]
+
+
+def test_disallowed_dunder_import():
+    executor = PythonExecutor()
+    result = executor.execute_code("__import__('os')")
+    assert result["success"] is False
+    assert "Disallowed" in result["error"]
+
+
 def test_timeout_loop():
     executor = PythonExecutor()
     result = executor.execute_code("while True:\n    pass")


### PR DESCRIPTION
## Summary
- Test PythonExecutor rejection of `open`, `exec`, and `__import__`
- Explain execution sandboxing and resource limits in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4b5a06b9c83339efed09e34abe41b