### PR TITLE
Add LLM-based parser and client with tests

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+try:  # pragma: no cover - optional dependency
+    from openai import OpenAI
+except Exception:  # pragma: no cover - handled at runtime
+    OpenAI = None
+
+
+@dataclass
+class LLMClient:
+    """Light wrapper around the OpenAI client with deterministic settings."""
+
+    model: str = "gpt-4o-mini"
+    temperature: float = 0.0
+    _client: OpenAI = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if OpenAI is None:  # pragma: no cover - optional dependency
+            raise ImportError("openai package is required for LLMClient")
+        self._client = OpenAI()
+
+    def complete(self, prompt: str) -> str:
+        """Return completion text for the given prompt."""
+        response = self._client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=self.temperature,
+        )
+        return response.choices[0].message["content"].strip()

--- a/llm_parser.py
+++ b/llm_parser.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class LLMClientProtocol(Protocol):
+    """Protocol describing the minimal LLM client interface used."""
+
+    def complete(self, prompt: str) -> str:
+        ...
+
+
+FOUR_STEP_PROMPT = (
+    "Use a four-step process: 1) analyze the task, 2) plan the solution, "
+    "3) draft Python code, 4) return only the Python code."
+)
+
+
+@dataclass
+class LLMParser:
+    """Parser that delegates code generation to an LLM client."""
+
+    client: LLMClientProtocol
+
+    def parse(self, command: str) -> str:
+        """Generate Python code from a natural language command."""
+        step1 = self.client.complete(f"Step 1 - Analyze the task:\n{command}")
+        step2 = self.client.complete(
+            f"Step 2 - Plan the solution.\nTask: {command}\nAnalysis: {step1}"
+        )
+        step3 = self.client.complete(
+            f"Step 3 - Draft Python code.\nPlan: {step2}"
+        )
+        final = self.client.complete(
+            "Step 4 - Return ONLY the final Python code."\
+            f"\n{step3}"
+        )
+        return self._extract_code(final)
+
+    def _extract_code(self, text: str) -> str:
+        """Extract Python code from an LLM response."""
+        if "```" not in text:
+            return text.strip()
+        parts = text.split("```")
+        for part in parts:
+            stripped = part.strip()
+            if not stripped:
+                continue
+            if stripped.startswith("python"):
+                return stripped[len("python"):].strip()
+            return stripped
+        return text.strip()

--- a/tests/test_llm_parser.py
+++ b/tests/test_llm_parser.py
@@ -1,0 +1,37 @@
+from llm_parser import LLMParser
+
+
+class DummyClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def complete(self, prompt: str) -> str:
+        self.calls.append(prompt)
+        return self.responses.pop(0)
+
+
+def test_llm_parser_returns_final_code_from_backticks():
+    client = DummyClient([
+        "analysis",
+        "plan",
+        "draft",
+        "```python\nprint('hi')\n```",
+    ])
+    parser = LLMParser(client)
+    result = parser.parse("print hello")
+    assert result == "print('hi')"
+    assert len(client.calls) == 4
+
+
+def test_llm_parser_returns_plain_code():
+    client = DummyClient([
+        "analysis",
+        "plan",
+        "draft",
+        "print('hi')",
+    ])
+    parser = LLMParser(client)
+    result = parser.parse("print hello")
+    assert result == "print('hi')"
+    assert len(client.calls) == 4


### PR DESCRIPTION
## Summary
- Add `LLMClient` wrapper around OpenAI with deterministic temperature
- Implement `LLMParser` that performs a four-step chain to produce Python code
- Include unit tests for LLM parser mocking client responses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4e68970748333aff51fc43068d139