### PR TITLE
Allow arbitrary instructions via API and add integration test

### DIFF
--- a/api.py
+++ b/api.py
@@ -15,21 +15,6 @@ app = FastAPI()
 logger = logging.getLogger("api")
 logging.basicConfig(level=logging.INFO)
 
-ALLOWED_COMMANDS = {
-    "load",
-    "clean",
-    "encode",
-    "scale",
-    "split",
-    "build",
-    "fit",
-    "transform",
-    "evaluate",
-    "save",
-    "train",
-    "reset",
-}
-
 class CommandRequest(BaseModel):
     command: str
     session_id: str | None = None
@@ -57,7 +42,6 @@ def _get_session(session_id: str | None):
 def execute(req: CommandRequest):
     start = time.time()
     cmd = req.command.strip()
-    first = cmd.split(" ", 1)[0].lower()
 
     if cmd.lower() == "reset session":
         if req.session_id:
@@ -65,10 +49,6 @@ def execute(req: CommandRequest):
         session = start_session()
         logger.info("cmd='reset session' duration=%.3fs success=True", time.time() - start)
         return CommandResponse(session_id=session.id, success=True, output="Session reset.")
-
-    if first not in ALLOWED_COMMANDS:
-        logger.warning("cmd=%s not allowed", cmd)
-        raise HTTPException(status_code=400, detail="Command not permitted.")
 
     session = _get_session(req.session_id)
     executor = NaturalLanguageExecutor()

--- a/tests/test_arbitrary_instructions.py
+++ b/tests/test_arbitrary_instructions.py
@@ -1,0 +1,30 @@
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from api import app
+from execution import NaturalLanguageExecutor
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_arbitrary_instruction_reaches_executor(client, monkeypatch):
+    captured = {}
+
+    def fake_execute(self, command: str):
+        captured["command"] = command
+        return "executor response"
+
+    monkeypatch.setattr(NaturalLanguageExecutor, "execute", fake_execute)
+
+    cmd = "sing a song about data"
+    resp = client.post("/execute", json={"command": cmd})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"]
+    assert data["output"] == "executor response"
+    assert captured["command"] == cmd


### PR DESCRIPTION
## Summary
- Remove command whitelist to accept arbitrary instructions
- Add integration test ensuring raw instructions reach executor

## Testing
- `pytest -q` *(fails: can't start new thread in tests/test_python_executor.py: RuntimeError: can't start new thread)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ee7e454c8333a163fd6f884085ca