### PR TITLE
Add LLM-based command fallback with configurable client

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import os
 
 try:  # pragma: no cover - optional dependency
     from openai import OpenAI
@@ -8,12 +9,25 @@ except Exception:  # pragma: no cover - handled at runtime
     OpenAI = None
 
 
+def _default_model() -> str:
+    """Default model name configurable via ``LLM_MODEL`` env var."""
+    return os.getenv("LLM_MODEL", "gpt-4o-mini")
+
+
+def _default_temperature() -> float:
+    """Default temperature configurable via ``LLM_TEMPERATURE`` env var."""
+    try:
+        return float(os.getenv("LLM_TEMPERATURE", "0.0"))
+    except ValueError:  # pragma: no cover - invalid env value
+        return 0.0
+
+
 @dataclass
 class LLMClient:
-    """Light wrapper around the OpenAI client with deterministic settings."""
+    """Light wrapper around the OpenAI client with configurable settings."""
 
-    model: str = "gpt-4o-mini"
-    temperature: float = 0.0
+    model: str = field(default_factory=_default_model)
+    temperature: float = field(default_factory=_default_temperature)
     _client: OpenAI = field(init=False, repr=False)
 
     def __post_init__(self) -> None:

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,32 @@
+import llm_client
+from llm_client import LLMClient
+
+
+class DummyCompletions:
+    def __init__(self):
+        self.last_args = None
+
+    def create(self, model, messages, temperature):
+        self.last_args = (model, messages, temperature)
+        class Resp:
+            choices = [type('obj', (), {'message': {'content': 'ok'}})]
+        return Resp()
+
+
+class DummyChat:
+    def __init__(self):
+        self.completions = DummyCompletions()
+
+
+class DummyOpenAI:
+    def __init__(self):
+        self.chat = DummyChat()
+
+
+def test_llm_client_configuration(monkeypatch):
+    monkeypatch.setattr(llm_client, "OpenAI", DummyOpenAI)
+    client = LLMClient(model="test-model", temperature=0.5)
+    text = client.complete("hi")
+    assert text == "ok"
+    assert client._client.chat.completions.last_args[0] == "test-model"
+    assert client._client.chat.completions.last_args[2] == 0.5

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -1,0 +1,27 @@
+from llm_parser import LLMParser
+from execution import NaturalLanguageExecutor
+
+
+class DummyClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+
+    def complete(self, prompt: str) -> str:
+        return self.responses.pop(0)
+
+
+def test_executor_uses_llm_fallback():
+    executor = NaturalLanguageExecutor()
+    executor.llm_parser = LLMParser(DummyClient([
+        "analysis",
+        "plan",
+        "draft",
+        "print('hi')",
+    ]))
+    # Avoid spawning subprocesses during tests
+    def fake_execute(code: str) -> str:
+        return code
+
+    executor._execute_with_real_python = fake_execute  # type: ignore[attr-defined]
+    result = executor.execute("tell me a joke")
+    assert result == "print('hi')"


### PR DESCRIPTION
## Summary
- allow configuring model and temperature via environment in `LLMClient`
- add an LLM parser to `NaturalLanguageExecutor` and use it as a final fallback
- test LLM parser fallback and client configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a54182a8308333a2a3cbd1865afaf8