### PR TITLE
Add ML parser training CLI and dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ print(result)
 The example above generates and executes Python code even when no
 rule-based template matches the query.
 
+## Training
+
+The optional ML parser can be retrained on a JSON dataset of command/code
+pairs. Edit `datasets/commands.json` with your own examples and run:
+
+```bash
+python scripts/train_parser.py --dataset datasets/commands.json --output models/ml_parser.json
+```
+
+The script trains a sentence-transformer model, saves it to the specified
+path and reports accuracy on the provided dataset.
+
 ## Prompt design
 
 The parser expects concise, imperative instructions:

--- a/datasets/commands.json
+++ b/datasets/commands.json
@@ -1,0 +1,7 @@
+[
+  {"query": "print hello world", "code": "print('hello world')"},
+  {"query": "sum numbers 1 to 10", "code": "sum(range(1, 11))"},
+  {"query": "reverse string abc", "code": "'abc'[::-1]"},
+  {"query": "list of squares 0 to 9", "code": "[i*i for i in range(10)]"},
+  {"query": "sort list 3 1 2", "code": "sorted([3, 1, 2])"}
+]

--- a/scripts/train_parser.py
+++ b/scripts/train_parser.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Train the ML parser model from a dataset of command/code pairs."""
+from __future__ import annotations
+
+import argparse
+
+from ml_parser import DEFAULT_MODEL_NAME, MLCodeGenerator, load_corpus
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train ML code parser")
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default="datasets/commands.json",
+        help="Path to JSON dataset with 'query' and 'code' entries",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="models/ml_parser.json",
+        help="Where to store the trained model",
+    )
+    parser.add_argument(
+        "--model-name",
+        type=str,
+        default=DEFAULT_MODEL_NAME,
+        help="SentenceTransformer model to use",
+    )
+    args = parser.parse_args()
+
+    dataset = load_corpus(args.dataset)
+    model = MLCodeGenerator.train(dataset, model_name=args.model_name)
+    model.save(args.output)
+
+    # Evaluate training accuracy
+    total = len(dataset)
+    correct = sum(1 for item in dataset if model.predict(item["query"]) == item["code"])
+    accuracy = correct / total if total else 0.0
+    print(f"Accuracy: {accuracy:.2%} ({correct}/{total})")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- Add small dataset of command/code pairs for ML parser training
- Implement `scripts/train_parser.py` to train and evaluate `MLCodeGenerator`
- Document training usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a54354b8948333bdfd64e2524a095f