### PR TITLE
Add NLP-based pronoun and unit handling to ParameterExtractor

### DIFF
--- a/tests/test_parameter_extractor.py
+++ b/tests/test_parameter_extractor.py
@@ -10,6 +10,9 @@ def make_extractor():
     return ParameterExtractor(ctx)
 
 
+spacy_available = make_extractor().nlp is not None
+
+
 def test_number_word():
     extractor = make_extractor()
     assert extractor.extract_value("two") == 2
@@ -39,3 +42,24 @@ def test_unknown_identifier_error():
     extractor = make_extractor()
     with pytest.raises(ParameterExtractionError):
         extractor.extract_identifier("")
+
+
+def test_unit_parsing():
+    extractor = make_extractor()
+    assert extractor.extract_value("two dozen") == 24
+
+
+@pytest.mark.skipif(not spacy_available, reason="spaCy not installed")
+def test_plural_identifier_resolution():
+    extractor = make_extractor()
+    assert extractor.extract_identifier("users") == "user"
+
+
+@pytest.mark.skipif(not spacy_available, reason="spaCy not installed")
+def test_pronoun_plural_resolution():
+    ctx = ExecutionContext()
+    ctx.add_variable("numbers", [1, 2, 3])
+    ctx.last_collection = "numbers"
+    extractor = ParameterExtractor(ctx)
+    assert extractor.extract_identifier("them") == "numbers"
+


### PR DESCRIPTION
## Summary
- integrate spaCy in `ParameterExtractor` for pronoun and plural resolution
- add synonym tables and unit parsing (e.g. dozen) to value extraction
- cover new parsing cases in tests

## Testing
- `pytest tests/test_parameter_extractor.py`
- `pytest` *(fails: test_python_executor.py::test_success_execution, test_python_executor.py::test_runtime_error)*

------
https://chatgpt.com/codex/tasks/task_e_68a544298ac8833393a9a3913d9b33cf