### PR TITLE
Improve error reporting and suggestions

### DIFF
--- a/errors.py
+++ b/errors.py
@@ -1,0 +1,31 @@
+class UnknownVerbError(ValueError):
+    """Raised when a command verb is not recognized."""
+
+    def __init__(self, verb: str, suggestion: str | None = None) -> None:
+        message = f"Sorry, I don't understand: '{verb}'"
+        if suggestion:
+            message += f". Did you mean: '{suggestion}'?"
+        super().__init__(message)
+        self.verb = verb
+        self.suggestion = suggestion
+
+
+class MissingParameterError(ValueError):
+    """Raised when required parameters are missing."""
+
+    def __init__(self, params: list[str], suggestion: str | None = None) -> None:
+        missing = ", ".join(params)
+        message = f"Missing parameters: {missing}"
+        if suggestion:
+            message += f". Did you mean: '{suggestion}'?"
+        super().__init__(message)
+        self.params = params
+        self.suggestion = suggestion
+
+
+class UnsupportedLibraryError(ValueError):
+    """Raised when an optional library required for a task isn't available."""
+
+    def __init__(self, library: str) -> None:
+        super().__init__(f"Unsupported library: {library}")
+        self.library = library

--- a/templates/pandas.py
+++ b/templates/pandas.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Any
 
+from errors import MissingParameterError, UnsupportedLibraryError
+
 
 def _parse_version(v: str) -> tuple[int, ...]:
     parts = []
@@ -32,9 +34,11 @@ class Template:
     code: str
 
     def generate(self, **kwargs: Any) -> str:
+        if not HAS_PANDAS:
+            raise UnsupportedLibraryError("pandas")
         missing = set(self.parameters) - set(kwargs)
         if missing:
-            raise ValueError(f"Missing parameters: {missing}")
+            raise MissingParameterError(sorted(missing))
         return self.code.format(**kwargs)
 
 

--- a/templates/sklearn.py
+++ b/templates/sklearn.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Any
 
+from errors import MissingParameterError, UnsupportedLibraryError
+
 
 def _parse_version(v: str) -> tuple[int, ...]:
     parts = []
@@ -36,9 +38,11 @@ class Template:
     code: str
 
     def generate(self, **kwargs: Any) -> str:
+        if not HAS_SKLEARN:
+            raise UnsupportedLibraryError("sklearn")
         missing = set(self.parameters) - set(kwargs)
         if missing:
-            raise ValueError(f"Missing parameters: {missing}")
+            raise MissingParameterError(sorted(missing))
         return self.code.format(**kwargs)
 
 

--- a/tests/test_unknown_commands.py
+++ b/tests/test_unknown_commands.py
@@ -1,11 +1,22 @@
+import pytest
+
 from parsing import ExecutionTemplate
 from execution import NaturalLanguageExecutor
+from errors import UnknownVerbError
 
 
 def test_unknown_command_message():
     executor = NaturalLanguageExecutor()
-    result = executor.execute("gibberish command")
-    assert "Sorry, I don't understand" in result
+    with pytest.raises(UnknownVerbError) as exc:
+        executor.execute("gibberish command")
+    assert "Sorry, I don't understand" in str(exc.value)
+
+
+def test_suggestion_for_typo():
+    executor = NaturalLanguageExecutor()
+    with pytest.raises(UnknownVerbError) as exc:
+        executor.execute("pritn 5")
+    assert "Did you mean" in str(exc.value)
 
 
 


### PR DESCRIPTION
## Summary
- Define custom exceptions for unknown verbs, missing parameters and unsupported libraries
- Suggest likely commands for unrecognized input in `NaturalLanguageExecutor.execute`
- Guard pandas and scikit-learn templates with library checks and updated tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5491392ac8333a89afc26dc15522f