### PR TITLE
feat: enhance LLM interaction with context and verification

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -970,7 +970,11 @@ class NaturalLanguageExecutor:
         if not self.llm_parser:
             return None
         try:
-            code = self.llm_parser.parse(text)
+            code = self.llm_parser.parse(
+                text,
+                conversation_history=self.conversation_history,
+                session_variables=self.context.variables,
+            )
             return self._execute_with_real_python(code)
         except Exception:
             return None

--- a/llm_parser.py
+++ b/llm_parser.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
+import ast
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Dict, List, Protocol, Tuple
 
 
 class LLMClientProtocol(Protocol):
     """Protocol describing the minimal LLM client interface used."""
 
-    def complete(self, prompt: str) -> str:
+    def complete(
+        self,
+        prompt: str,
+        *,
+        history: List[Dict[str, str]] | None = None,
+        session: Dict[str, str] | None = None,
+        model: str | None = None,
+        temperature: float | None = None,
+    ) -> str:
         ...
 
 
@@ -23,20 +32,65 @@ class LLMParser:
 
     client: LLMClientProtocol
 
-    def parse(self, command: str) -> str:
+    def parse(
+        self,
+        command: str,
+        *,
+        conversation_history: List[Tuple[str, str]] | None = None,
+        session_variables: Dict[str, Any] | None = None,
+        model: str | None = None,
+        temperature: float | None = None,
+    ) -> str:
         """Generate Python code from a natural language command."""
-        step1 = self.client.complete(f"Step 1 - Analyze the task:\n{command}")
-        step2 = self.client.complete(
+
+        history: List[Dict[str, str]] = []
+        if session_variables:
+            session_text = "\n".join(
+                f"{k} = {repr(v)}" for k, v in session_variables.items()
+            )
+            history.append({"role": "system", "content": f"Session variables:\n{session_text}"})
+        if conversation_history:
+            for role, content in conversation_history:
+                history.append({"role": role, "content": content})
+
+        def _ask(prompt: str) -> str:
+            response = self.client.complete(
+                prompt,
+                history=history,
+                model=model,
+                temperature=temperature,
+            )
+            history.append({"role": "user", "content": prompt})
+            history.append({"role": "assistant", "content": response})
+            return response
+
+        step1 = _ask(f"Step 1 - Analyze the task:\n{command}")
+        step2 = _ask(
             f"Step 2 - Plan the solution.\nTask: {command}\nAnalysis: {step1}"
         )
-        step3 = self.client.complete(
-            f"Step 3 - Draft Python code.\nPlan: {step2}"
+        step3 = _ask(f"Step 3 - Draft Python code.\nPlan: {step2}")
+        final = _ask(
+            "Step 4 - Return ONLY the final Python code.\n" + step3
         )
-        final = self.client.complete(
-            "Step 4 - Return ONLY the final Python code."\
-            f"\n{step3}"
-        )
-        return self._extract_code(final)
+
+        code = self._extract_code(final)
+
+        try:
+            ast.parse(code)
+            return code
+        except SyntaxError as exc:
+            retry = _ask(
+                "The previous code had a syntax error: "
+                f"{exc}. Please fix it and return only valid Python code.\n{code}"
+            )
+            code = self._extract_code(retry)
+            try:
+                ast.parse(code)
+            except SyntaxError as exc2:
+                raise ValueError(
+                    f"Generated code could not be parsed: {exc2.msg}"
+                ) from exc2
+            return code
 
     def _extract_code(self, text: str) -> str:
         """Extract Python code from an LLM response."""

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -6,7 +6,7 @@ class DummyClient:
     def __init__(self, responses):
         self.responses = list(responses)
 
-    def complete(self, prompt: str) -> str:
+    def complete(self, prompt: str, **_: object) -> str:
         return self.responses.pop(0)
 
 

--- a/tests/test_llm_parser.py
+++ b/tests/test_llm_parser.py
@@ -6,7 +6,7 @@ class DummyClient:
         self.responses = list(responses)
         self.calls = []
 
-    def complete(self, prompt: str) -> str:
+    def complete(self, prompt: str, **_: object) -> str:
         self.calls.append(prompt)
         return self.responses.pop(0)
 
@@ -22,6 +22,40 @@ def test_llm_parser_returns_final_code_from_backticks():
     result = parser.parse("print hello")
     assert result == "print('hi')"
     assert len(client.calls) == 4
+
+
+class HistoryClient:
+    def __init__(self):
+        self.calls = []
+        self.responses = [
+            "analysis",
+            "plan",
+            "```python\nprint('hi'\n```",
+            "```python\nprint('hi'\n```",
+            "```python\nprint('hi')\n```",
+        ]
+
+    def complete(self, prompt, *, history=None, session=None, model=None, temperature=None):
+        idx = len(self.calls)
+        self.calls.append({"prompt": prompt, "history": history})
+        return self.responses[idx]
+
+
+def test_llm_parser_history_and_verification():
+    client = HistoryClient()
+    parser = LLMParser(client)
+    history = [("user", "prev cmd"), ("assistant", "prev resp")]
+    session = {"x": 1}
+    code = parser.parse(
+        "say hi",
+        conversation_history=history,
+        session_variables=session,
+    )
+    assert code == "print('hi')"
+    first_history = client.calls[0]["history"]
+    assert first_history[0] == {"role": "system", "content": "Session variables:\nx = 1"}
+    assert first_history[1] == {"role": "user", "content": "prev cmd"}
+    assert len(client.calls) == 5
 
 
 def test_llm_parser_returns_plain_code():


### PR DESCRIPTION
## Summary
- Pass conversation history and session variables to each LLM prompt
- Retry code generation after AST parsing errors
- Allow overriding model and temperature per request

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a55d1f30b8833386fd3fbcf59727a9