### PR TITLE
Add TF-IDF fallback for ML parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ The project relies on a few Python packages:
 
 * **Mandatory**: [`pandas`](https://pandas.pydata.org/) and [`scikit-learn`](https://scikit-learn.org/)
   for dataframe operations and ML utilities.
-* **Optional**: [`sentence_transformers`](https://www.sbert.net/) enables an
-  embedding-based ML fallback when rule-based parsing fails.
+* **Optional**: [`sentence_transformers`](https://www.sbert.net/) provides
+  transformer-based embeddings. When it's unavailable, a simpler
+  `TfidfVectorizer` from `scikit-learn` is used with reduced accuracy.
 
 ## Installation
 
@@ -64,7 +65,10 @@ print(result)
 ```
 
 The example above generates and executes Python code even when no
-rule-based template matches the query.
+rule-based template matches the query. When the
+`sentence_transformers` library is not available, this mode uses a
+simple TF-IDF vectorizer instead of transformer embeddings, so matches
+may be less accurate.
 
 ## Training
 
@@ -76,7 +80,10 @@ python scripts/train_parser.py --dataset datasets/commands.json --output models/
 ```
 
 The script trains a sentence-transformer model, saves it to the specified
-path and reports accuracy on the provided dataset.
+path and reports accuracy on the provided dataset. If the
+`sentence_transformers` package is missing, the training script falls back
+to a simple TF-IDF model. This lightweight backend is easier to install but
+offers much weaker semantic matching and generally lower accuracy.
 
 ## Prompt design
 

--- a/scripts/train_parser.py
+++ b/scripts/train_parser.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import argparse
 
+import warnings
+
 from ml_parser import DEFAULT_MODEL_NAME, MLCodeGenerator, load_corpus
 
 
@@ -31,6 +33,11 @@ def main() -> None:
 
     dataset = load_corpus(args.dataset)
     model = MLCodeGenerator.train(dataset, model_name=args.model_name)
+    if model.model_name == "tfidf":
+        warnings.warn(
+            "SentenceTransformer unavailable; falling back to TfidfVectorizer",
+            RuntimeWarning,
+        )
     model.save(args.output)
 
     # Evaluate training accuracy


### PR DESCRIPTION
## Summary
- Support TF-IDF embeddings when `sentence_transformers` isn't installed
- Warn when training falls back to TF-IDF backend
- Document embedding fallback and limitations

## Testing
- `pip install scikit-learn` *(failed: Could not connect to proxy)*
- `pytest` *(failed: RuntimeError: can't start new thread)*

------
https://chatgpt.com/codex/tasks/task_e_68a76dc6d11c8333b520383ffe876e9c